### PR TITLE
`Path.__str__` でcloudのURIも正しくformatできるようにする

### DIFF
--- a/cloudio/cached_path.py
+++ b/cloudio/cached_path.py
@@ -19,7 +19,7 @@ import requests
 from cloudio.config import get_config
 from cloudio.s3 import s3_download_fileobj, s3_etag
 from cloudio.tqdm import Tqdm
-from cloudio.utils import to_str
+from cloudio.utils import format_path_or_url
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -75,7 +75,7 @@ def cached_path(url_or_filename: Union[str, Path], cache_dir: str = None) -> str
     return the path to the cached file. If it's already a local path,
     make sure the file exists and then return the path.
     """
-    url_or_filename = to_str(url_or_filename)
+    url_or_filename = format_path_or_url(url_or_filename)
     if cache_dir is None:
         cache_dir = get_config("cache_dir")
 
@@ -105,7 +105,7 @@ def is_url_or_existing_file(url_or_filename: Union[str, Path, None]) -> bool:
     """
     if url_or_filename is None:
         return False
-    url_or_filename = to_str(url_or_filename)
+    url_or_filename = format_path_or_url(url_or_filename)
     url_or_filename = os.path.expanduser(url_or_filename)
     parsed = urlparse(url_or_filename)
     return parsed.scheme in ("http", "https", "s3") or os.path.exists(url_or_filename)

--- a/cloudio/upload.py
+++ b/cloudio/upload.py
@@ -8,14 +8,14 @@ from uuid import uuid4
 
 from cloudio import get_config
 from cloudio.s3 import s3_upload_file, s3_upload_folder
-from cloudio.utils import to_str
+from cloudio.utils import format_path_or_url
 
 logger = getLogger(__name__)
 
 
 def upload(url: str, path: Union[str, Path]) -> None:
-    url = to_str(url)
-    path = to_str(path)
+    url = format_path_or_url(url)
+    path = format_path_or_url(path)
 
     parsed = urlparse(url)
     if parsed.scheme == "s3":
@@ -29,7 +29,7 @@ def upload(url: str, path: Union[str, Path]) -> None:
 
 @contextmanager
 def upload_later(cloud_or_local_path: Union[str, Path]) -> Generator[str, None, None]:
-    cloud_or_local_path = to_str(cloud_or_local_path)
+    cloud_or_local_path = format_path_or_url(cloud_or_local_path)
     parsed = urlparse(cloud_or_local_path)
 
     # If path is local path, then yield it

--- a/cloudio/utils.py
+++ b/cloudio/utils.py
@@ -3,6 +3,11 @@ from pathlib import Path
 from typing import Union
 
 
+def fix_drive_str_in_path(path: str) -> str:
+    fixed = re.sub(r':/(?!/)', '://', path)
+    return fixed
+
+
 def to_str(path_or_url: Union[str, Path]) -> str:
     """ローカルへのパスまたはURLをstr型に変換する
 
@@ -13,9 +18,7 @@ def to_str(path_or_url: Union[str, Path]) -> str:
         return path_or_url
     elif isinstance(path_or_url, Path):
         path_or_url_str = str(path_or_url)
-        path_or_url_str = re.sub(r"^s3:/", "s3://", path_or_url_str)
-        path_or_url_str = re.sub(r"^http:/", "http://", path_or_url_str)
-        path_or_url_str = re.sub(r"^https:/", "https://", path_or_url_str)
+        path_or_url_str = fix_drive_str_in_path(path_or_url_str)
         return path_or_url_str
     else:
         raise TypeError

--- a/cloudio/utils.py
+++ b/cloudio/utils.py
@@ -22,3 +22,16 @@ def format_path_or_url(path_or_url: Union[str, Path]) -> str:
         return path_or_url_str
     else:
         raise TypeError
+
+
+def format_path_with_drive(path: Path) -> str:
+    """Formats `pathlib.Path` object."""
+
+    # below is the copy-and-paste of `pathlib.Path.__str__`
+    try:
+        formatted = path._str
+    except AttributeError:
+        formatted = path._format_parsed_parts(path._drv, path._root, path._parts) or '.'
+
+    formatted = fix_drive_str_in_path(formatted)
+    return formatted

--- a/cloudio/utils.py
+++ b/cloudio/utils.py
@@ -35,3 +35,8 @@ def format_path_with_drive(path: Path) -> str:
 
     formatted = fix_drive_str_in_path(formatted)
     return formatted
+
+
+def override_pathlib_str_for_drive() -> None:
+    """Replaces `Path.__str__` with `format_path_with_drive`"""
+    Path.__str__ = format_path_with_drive

--- a/cloudio/utils.py
+++ b/cloudio/utils.py
@@ -8,7 +8,7 @@ def fix_drive_str_in_path(path: str) -> str:
     return fixed
 
 
-def to_str(path_or_url: Union[str, Path]) -> str:
+def format_path_or_url(path_or_url: Union[str, Path]) -> str:
     """ローカルへのパスまたはURLをstr型に変換する
 
     単純にs3のパスをPath('s3://hoge')などとしてしまうと、//が/に変換され Path('s3:/hoge/fuga')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,17 +1,17 @@
 from pathlib import Path
 
-from cloudio.utils import to_str
+from cloudio.utils import format_path_or_url
 
 
-def test_to_str():
+def test_format_path_or_url():
     url = "http://hoge/fuga.txt"
-    assert to_str(Path(url)) == url
+    assert format_path_or_url(Path(url)) == url
 
     url = "https://hoge/fuga.txt"
-    assert to_str(Path(url)) == url
+    assert format_path_or_url(Path(url)) == url
 
     url = "s3://hoge/fuga.txt"
-    assert to_str(Path(url)) == url
+    assert format_path_or_url(Path(url)) == url
 
     url = "https://elyza-sandbox.s3.amazonaws.com/liz_ocr/shadow_sample1.jpg"
-    assert to_str(Path(url)) == url
+    assert format_path_or_url(Path(url)) == url


### PR DESCRIPTION
## WHY

外部モジュールで使うときわざわざ `to_str` を呼ぶのが面倒だった

## WHAT

- `override_pathlib_str_for_drive` を実行することで， `str(path)` でもURIの `:/` が `://` になる
    - `:/` -> `://` に変換する関数を定義
- rename `to_str` -> `format_path_or_url`
